### PR TITLE
Upgrade to iRODS v4.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This image allows for configuring Davrods and iRODS via environment variables. O
 Note that in our use case, secure connections are handled by Traefik in the
 docker-compose environment. Thus we configure the host internally as HTTP.
 
-This version supports iRODS v4.3.4 and may not be compatible with older or newer server versions.
+This version supports iRODS v4.3.5 and may not be compatible with older or newer server versions.
 
 ## Building
 
@@ -25,7 +25,7 @@ If you specify anything else then the startup script will `exec` this command (e
 
 | Variable name                       | Default Value                     |
 |-------------------------------------|-----------------------------------|
-| IRODS_PKG_VERSION                   | 4.3.4                             |
+| IRODS_PKG_VERSION                   | 4.3.5                             |
 | IRODS_HOST_NAME                     | localhost                         |
 | IRODS_ZONE_PORT                     | 1247                              |
 | IRODS_ZONE_NAME                     | sodarZone                         |

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 export REPO=ghcr.io/bihealth/davrods-docker
-export CONTAINER_VERSION=${CONTAINER_VERSION-4.3.4_1.5.2}
-export IRODS_PKG_VERSION=${IRODS_PKG_VERSION-4.3.4}
+export CONTAINER_VERSION=${CONTAINER_VERSION-4.3.5_1.5.2}
+export IRODS_PKG_VERSION=${IRODS_PKG_VERSION-4.3.5}
 export BUILD_VERSION=${BUILD_VERSION-1}
 
 docker build \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 FROM ubuntu:22.04 AS build
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG IRODS_PKG_VERSION="4.3.4"
+ARG IRODS_PKG_VERSION="4.3.5"
 
 RUN apt-get update
 RUN apt-get install -y apache2-dev git wget cmake
@@ -38,7 +38,8 @@ LABEL org.opencontainers.image.authors="mikko.nieminen@bih-charite.de"
 LABEL org.opencontainers.image.source="https://github.com/bihealth/davrods-docker"
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG IRODS_PKG_VERSION="4.3.4"
+ARG IRODS_PKG_VERSION="4.3.5"
+ARG DAVRODS_IRODS_PKG_VERSION="4.3.4"
 ARG DAVRODS_VERSION="1.5.2"
 
 # Environment variables for container runtime
@@ -75,7 +76,7 @@ RUN apt-get install -y python3-pip python3-jinja2 python3-yaml
 RUN pip install j2cli
 
 # Install Davrods
-RUN wget https://github.com/UtrechtUniversity/davrods/releases/download/${IRODS_PKG_VERSION}_${DAVRODS_VERSION}/davrods-${IRODS_PKG_VERSION}-${DAVRODS_VERSION}.deb -O /tmp/davrods.deb \
+RUN wget https://github.com/UtrechtUniversity/davrods/releases/download/${DAVRODS_IRODS_PKG_VERSION}_${DAVRODS_VERSION}/davrods-${DAVRODS_IRODS_PKG_VERSION}-${DAVRODS_VERSION}.deb -O /tmp/davrods.deb \
     && dpkg -i --force-depends /tmp/davrods.deb
 
 # Backup original vhost conf


### PR DESCRIPTION
This PR attempts to address #16. iRODS is updated, but davrods is kept at the same version as before.